### PR TITLE
Update main label for branches

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -77,7 +77,7 @@ def read_branch(c, workflow_name):
     with io.StringIO() as f:
         c.local('cd {} && git branch | grep \*'.format(workflow_name), out_stream = f)
         branch = f.getvalue().replace('\n','').replace('* ','')
-        if not ('HEAD detached' in branch or 'master' in branch):
+        if not ('HEAD detached' in branch or 'master' in branch or 'main' in branch):
             branch_name = branch
     return branch_name
 


### PR DESCRIPTION
Github no longer uses the antiquated "master" for the main branch in a repository.  This PR allows for the main branch to be called "main".

For more information see https://github.com/github/renaming.